### PR TITLE
Waiting on a process which is already dead is causing No child processes 

### DIFF
--- a/lib/headless/cli_util.rb
+++ b/lib/headless/cli_util.rb
@@ -50,6 +50,8 @@ class Headless
           Process.wait pid if options[:wait]
         rescue Errno::ESRCH
           # no such process; assume it's already killed
+        rescue Errno::ECHILD
+          # Process.wait tried to wait on a dead process
         end
       end
       


### PR DESCRIPTION
Waiting on a process which is already dead is causing No child processes (Errno::ECHILD). This fixes the issue.
