### PR TITLE
Wait raises ECHILD when child process is not found.

### DIFF
--- a/lib/headless/cli_util.rb
+++ b/lib/headless/cli_util.rb
@@ -50,6 +50,8 @@ class Headless
           Process.wait pid if options[:wait]
         rescue Errno::ESRCH
           # no such process; assume it's already killed
+        rescue Errno::ECHILD
+          # wait tried to wait on a dead process
         end
       end
       


### PR DESCRIPTION
Simple change to catch the ECHILD error when it happens and continue with the processing.

I really appreciate your gem!

Mauro
