### PR TITLE
fix a bug which always ruby exits with 0 (success) with Headless gem

### DIFF
--- a/lib/headless.rb
+++ b/lib/headless.rb
@@ -142,7 +142,9 @@ private
     unless @at_exit_hook_installed
       @at_exit_hook_installed = true
       at_exit do
+        exit_status = $!.status if $!.is_a?(SystemExit)
         destroy if @destroy_at_exit
+        exit exit_status if exit_status
       end
     end
   end


### PR DESCRIPTION
fix a bug which always ruby exits with 0 (success) with Headless gem. It caused "rake" command always exits 0 and CI server misunderstood the result of "rake spec"
