### PR TITLE
Fix Errno::ECHILD error

### DIFF
--- a/lib/headless/cli_util.rb
+++ b/lib/headless/cli_util.rb
@@ -50,6 +50,8 @@ class Headless
           Process.wait pid if options[:wait]
         rescue Errno::ESRCH
           # no such process; assume it's already killed
+        rescue Errno::ECHILD
+          # process has finished exiting between kill and wait
         end
       end
       


### PR DESCRIPTION
If the virtual buffer process exits between .kill and .wait, there is no PID to await.
We know there WAS a process because .kill(read_pid) confirms that the process exists.
So this is not a real error, just a bookkeeping error.

This patch handles that problem.

Work paid for by One to the World
