### PR TITLE
Fix the exit status to it properly returns the exit status from your test runs.

### DIFF
--- a/lib/headless.rb
+++ b/lib/headless.rb
@@ -142,7 +142,9 @@ private
     unless @at_exit_hook_installed
       @at_exit_hook_installed = true
       at_exit do
+        exit_status = $?.exitstatus if $?.is_a?(Process::Status)
         destroy if @destroy_at_exit
+        exit exit_status if exit_status
       end
     end
   end


### PR DESCRIPTION
This is almost the same fix as #12, however that fix did not properly pass the exit status for me... might be a ruby 1.9 thing.  This has been tested in ruby 1.8.7 and 1.9
