### PR TITLE
rspec2 now running properly as lib/headless is being required

### DIFF
--- a/spec/headless_spec.rb
+++ b/spec/headless_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/headless'
+require 'spec_helper'
 
 describe Headless do
   before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+$LOAD_PATH << File.expand_path(File.join('..', 'lib'), File.dirname(__FILE__))
+
+require 'headless'

--- a/spec/video_recorder_spec.rb
+++ b/spec/video_recorder_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/headless'
+require 'spec_helper'
 
 describe Headless::VideoRecorder do
   before do


### PR DESCRIPTION
Fixes custom_require.rb:36:in `require': cannot load such file -- lib/headless (LoadError)
