### PR TITLE
fixes failing video recorder spec

### DIFF
--- a/spec/video_recorder_spec.rb
+++ b/spec/video_recorder_spec.rb
@@ -1,11 +1,11 @@
-require 'lib/headless'
+require 'spec_helper'
 
 describe Headless::VideoRecorder do
   before do
     stub_environment
   end
 
-  describe "instaniation" do
+  describe "instantiation" do
     before do
       Headless::CliUtil.stub!(:application_exists?).and_return(false)
     end
@@ -26,25 +26,30 @@ describe Headless::VideoRecorder do
   end
 
   context "stopping video recording" do
+    let(:tmpfile) { '/tmp/ci.mov' }
+    let(:filename) { '/tmp/test.mov' }
+    let(:pidfile) { '/tmp/pid' }
+
     subject do
-      recorder = Headless::VideoRecorder.new(99, "1024x768x32", :pid_file_path => "/tmp/pid", :tmp_file_path => "/tmp/ci.mov")
+      recorder = Headless::VideoRecorder.new(99, "1024x768x32", :pid_file_path => pidfile, :tmp_file_path => tmpfile)
       recorder.start_capture
       recorder
     end
 
     describe "using #stop_and_save" do
       it "stops video recording and saves file" do
-        Headless::CliUtil.should_receive(:kill_process).with("/tmp/pid", :wait => true)
-        FileUtils.should_receive(:mv).with("/tmp/ci.mov", "/tmp/test.mov")
+        Headless::CliUtil.should_receive(:kill_process).with(pidfile, :wait => true)
+        File.should_receive(:exists?).with(tmpfile).and_return(true)
+        FileUtils.should_receive(:mv).with(tmpfile, filename)
 
-        subject.stop_and_save("/tmp/test.mov")
+        subject.stop_and_save(filename)
       end
     end
 
     describe "using #stop_and_discard" do
       it "stops video recording and deletes temporary file" do
-        Headless::CliUtil.should_receive(:kill_process).with("/tmp/pid", :wait => true)
-        FileUtils.should_receive(:rm).with("/tmp/ci.mov")
+        Headless::CliUtil.should_receive(:kill_process).with(pidfile, :wait => true)
+        FileUtils.should_receive(:rm).with(tmpfile)
 
         subject.stop_and_discard
       end


### PR DESCRIPTION
$ rspec spec/

Failures:

  1) Headless::VideoRecorder stopping video recording using #stop_and_save stops video recording and saves file
     Failure/Error: FileUtils.should_receive(:mv).with("/tmp/ci.mov", "/tmp/test.mov")
       (FileUtils).mv("/tmp/ci.mov", "/tmp/test.mov")
           expected: 1 time
           received: 0 times
     # ./spec/video_recorder_spec.rb:38:in `block (4 levels) in <top (required)>'
