### PR TITLE
removes Process.detach(pid)

### DIFF
--- a/lib/headless/cli_util.rb
+++ b/lib/headless/cli_util.rb
@@ -3,7 +3,7 @@ class Headless
     def self.application_exists?(app)
       `which #{app}`.strip != ""
     end
-    
+
     def self.ensure_application_exists!(app, error_message)
       if !self.application_exists?(app)
         raise Headless::Exception.new(error_message)
@@ -36,7 +36,6 @@ class Headless
         exec command
         exit! 127 # safeguard in case exec fails
       end
-      Process.detach(pid)
 
       File.open pid_filename, 'w' do |f|
         f.puts pid


### PR DESCRIPTION
Per the Ruby 1.9.3 docs:

Process.detach(pid)

Some operating systems retain the status of terminated child processes until the parent collects that status (normally using some variant of wait(). If the parent never collects this status, the child stays around as a zombie process. Process::detach prevents this by setting up a separate Ruby thread whose sole job is to reap the status of the process pid when it terminates. **Use detach only when you do not intent to explicitly wait for the child to terminate.**
