### PR TITLE
adds cucumber with wkhtmltopdf example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Running cucumber headless is now as simple as adding a before and after hook in 
       headless.start
     end
 
+## Cucumber with wkhtmltopdf
+
+_Note: this is true for other programs which may use headless at the same time as cucumber is running_
+
+When wkhtmltopdf is using Headless, and cucumber is invoking a block of code which uses a headless session, make sure to override the default display of cucumber to retain browser focus. Assuming wkhtmltopdf is using the default display of 99, make sure to set the display to a value != 99 in `features/support/env.rb` file. This may be the cause of `Connection refused - connect(2) (Errno::ECONNREFUSED)`.
+
+    headless = Headless.new(:display => '100')
+    headless.start
+
 ## Capturing video
 
 Video is captured using `ffmpeg`. You can install it on Debian/Ubuntu via `sudo apt-get install ffmpeg` or on OS X via `brew install ffmpeg`. You can capture video continuously or capture scenarios separately. Here is typical use case:


### PR DESCRIPTION
When running cucumber headlessly, if your code spawns another headless instance, the cucumber driver may lose focus yielding: `Connection refused - connect(2) (Errno::ECONNREFUSED)`. This patch brings this to light by adding an example in the README.
