### PR TITLE
Preserve exit status when recording video.

### DIFF
--- a/lib/headless/video/video_recorder.rb
+++ b/lib/headless/video/video_recorder.rb
@@ -22,7 +22,9 @@ class Headless
     def start_capture
       CliUtil.fork_process("#{CliUtil.path_to('ffmpeg')} -y -r 30 -g 600 -s #{@dimensions} -f x11grab -i :#{@display} -vcodec qtrle #{@tmp_file_path}", @pid_file_path, @log_file_path)
       at_exit do
+        exit_status = $!.status if $!.is_a?(SystemExit)
         stop_and_discard
+        exit exit_status if exit_status
       end
     end
 


### PR DESCRIPTION
Added a commit that preserves exit status for the video recorder. This is very similar to pull request 12. Our Jenkins server thought that the rspec test completed successfully since ffmpeg returned a status of 0.
