### PR TITLE
Pass dimensions correctly to ffmpeg

### DIFF
--- a/lib/headless/video/video_recorder.rb
+++ b/lib/headless/video/video_recorder.rb
@@ -8,7 +8,7 @@ class Headless
       CliUtil.ensure_application_exists!('ffmpeg', 'Ffmpeg not found on your system. Install it with sudo apt-get install ffmpeg')
 
       @display = display
-      @dimensions = dimensions
+      @dimensions = dimensions[/.+(?=x)/]
 
       @pid_file_path = options.fetch(:pid_file_path, "/tmp/.headless_ffmpeg_#{@display}.pid")
       @tmp_file_path = options.fetch(:tmp_file_path, "/tmp/.headless_ffmpeg_#{@display}.mov")

--- a/spec/video_recorder_spec.rb
+++ b/spec/video_recorder_spec.rb
@@ -18,7 +18,7 @@ describe Headless::VideoRecorder do
   describe "#capture" do
     it "starts ffmpeg" do
       Headless::CliUtil.stub(:path_to).and_return('ffmpeg')
-      Headless::CliUtil.should_receive(:fork_process).with(/ffmpeg -y -r 30 -g 600 -s 1024x768x32 -f x11grab -i :99 -vcodec qtrle/, "/tmp/.headless_ffmpeg_99.pid", '/dev/null')
+      Headless::CliUtil.should_receive(:fork_process).with(/ffmpeg -y -r 30 -g 600 -s 1024x768 -f x11grab -i :99 -vcodec qtrle/, "/tmp/.headless_ffmpeg_99.pid", '/dev/null')
 
       recorder = Headless::VideoRecorder.new(99, "1024x768x32")
       recorder.start_capture
@@ -26,7 +26,7 @@ describe Headless::VideoRecorder do
 
     it "starts ffmpeg with specified codec" do
       Headless::CliUtil.stub(:path_to).and_return('ffmpeg')
-      Headless::CliUtil.should_receive(:fork_process).with(/ffmpeg -y -r 30 -g 600 -s 1024x768x32 -f x11grab -i :99 -vcodec libvpx/, "/tmp/.headless_ffmpeg_99.pid", '/dev/null')
+      Headless::CliUtil.should_receive(:fork_process).with(/ffmpeg -y -r 30 -g 600 -s 1024x768 -f x11grab -i :99 -vcodec libvpx/, "/tmp/.headless_ffmpeg_99.pid", '/dev/null')
 
       recorder = Headless::VideoRecorder.new(99, "1024x768x32", {:codec => 'libvpx'})
       recorder.start_capture


### PR DESCRIPTION
ffmpeg man tells that they should be passed as "wxh".
Currently they are passed as "wxhxd" which produces a failure in FFmpeg 1.2
