### PR TITLE
Updated an option to indicate which team (libav or ffmpeg developers) supplied ffmpeg, added ability to pass extra options to ffmpeg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .bundle
 Gemfile.lock
 pkg/*
+.idea
+

--- a/README.md
+++ b/README.md
@@ -120,6 +120,23 @@ After do |scenario|
 end
 ```
 
+### Video options
+
+When initiating Headless you may pass a hash with video options.
+
+```ruby
+headless = Headless.new(:video => { :frame_rate => 12, :codec => 'libx264' })
+```
+
+Available options:
+
+* :codec - codec to be used by ffmpeg
+* :frame_rate - frame rate of video capture
+* :provider - ffmpeg provider - either :libav (default) or :ffmpeg
+* :pid_file_path - path to ffmpeg pid file, default: "/tmp/.headless_ffmpeg_#{@display}.pid"
+* :tmp_file_path - path to tmp video file,  default: "/tmp/.headless_ffmpeg_#{@display}.mov"
+* :log_file_path - ffmpeg log file,         default: "/dev/null"
+
 ## Taking screenshots
 
 Images are captured using `import` utility which is part of `imagemagick` library. You can install it on Ubuntu via `sudo apt-get install imagemagick`. You can call `headless.take_screenshot` at any time. You have to supply full path to target file. File format is determined by supplied file extension.

--- a/README.md
+++ b/README.md
@@ -131,11 +131,12 @@ headless = Headless.new(:video => { :frame_rate => 12, :codec => 'libx264' })
 Available options:
 
 * :codec - codec to be used by ffmpeg
-* :frame_rate - frame rate of video capture
-* :provider - ffmpeg provider - either :libav (default) or :ffmpeg
+* :frame_rate    - frame rate of video capture
+* :provider      - ffmpeg provider - either :libav (default) or :ffmpeg
 * :pid_file_path - path to ffmpeg pid file, default: "/tmp/.headless_ffmpeg_#{@display}.pid"
 * :tmp_file_path - path to tmp video file,  default: "/tmp/.headless_ffmpeg_#{@display}.mov"
 * :log_file_path - ffmpeg log file,         default: "/dev/null"
+* :extra         - array of extra ffmpeg options, default: [] 
 
 ## Taking screenshots
 

--- a/README.md
+++ b/README.md
@@ -140,11 +140,29 @@ Available options:
 
 ## Taking screenshots
 
-Images are captured using `import` utility which is part of `imagemagick` library. You can install it on Ubuntu via `sudo apt-get install imagemagick`. You can call `headless.take_screenshot` at any time. You have to supply full path to target file. File format is determined by supplied file extension.
+Call `headless.take_screenshot` to take a screenshot. It needs two arguments:
 
+- file_path - path where the image should be stored
+- options - options, that can be:
+    :using - :import or :xwd, :import is default, if :import is used, image format is determined by file_path extension
+
+Screenshots can be taken by either using `import` (part of `imagemagick` library) or `xwd` utility.
+
+`import` captures a screenshot and saves it in the format of the specified file. It is convenient but not too fast as 
+it has to do the encoding synchronously.
+
+`xwd` will capture a screenshot very fast and store it in its own format, which can then be converted to one 
+of other picture formats using, for example, netpbm utilities - `xwdtopnm <xwd_file> | pnmtopng > capture.png`.
+
+To install the necessary libraries on ubuntu:
+
+`import` - run `sudo apt-get install imagemagick`
+`xwd` - run `sudo apt-get install X11-apps` and if you are going to use netpbm utilities for image conversion - `sudo apt-get install netpbm`
+ 
 ## Contributors
 
 * [Igor Afonov](http://iafonov.github.com) - video and screenshot capturing functionality.
+* [Yurie Nagorny](https://github.com/ynagorny) - xwd optiuon for screenshot taking
 
 ---
 

--- a/lib/headless.rb
+++ b/lib/headless.rb
@@ -115,10 +115,17 @@ class Headless
     @video_recorder ||= VideoRecorder.new(display, dimensions, @video_capture_options)
   end
 
-  def take_screenshot(file_path)
-    CliUtil.ensure_application_exists!('import', "imagemagick not found on your system. Please install it using sudo apt-get install imagemagick")
-
-    system "#{CliUtil.path_to('import')} -display localhost:#{display} -window root #{file_path}"
+  def take_screenshot(file_path, options={})
+    using = options.fetch(:using, :import)
+    if using == :import
+      CliUtil.ensure_application_exists!('import', "imagemagick is not found on your system. Please install it using sudo apt-get install imagemagick")
+      system "#{CliUtil.path_to('import')} -display localhost:#{display} -window root #{file_path}"
+    elsif using == :xwd
+      CliUtil.ensure_application_exists!('xwd', "xwd is not found on your system. Please install it using sudo apt-get install X11-apps")
+      system "#{CliUtil.path_to('xwd')} -display localhost:#{display} -silent -root -out #{file_path}"
+    else
+      raise Headless::Exception.new('Unknown :using option value')
+    end
   end
 
 private

--- a/lib/headless/video/video_recorder.rb
+++ b/lib/headless/video/video_recorder.rb
@@ -16,6 +16,8 @@ class Headless
       @codec = options.fetch(:codec, "qtrle")
       @frame_rate = options.fetch(:frame_rate, 30)
       @provider = options.fetch(:provider, :libav)  # or :ffmpeg
+      @extra = options.fetch(:extra, [])
+      @extra = [ @extra ] unless @extra.kind_of? Array
     end
 
     def capture_running?
@@ -31,7 +33,9 @@ class Headless
         dimensions = @dimensions.match(/^(\d+x\d+)/)[0]
       end
 
-      CliUtil.fork_process("#{CliUtil.path_to('ffmpeg')} -y -r #{@frame_rate} #{group_of_pic_size_option} -s #{dimensions} -f x11grab -i :#{@display} -vcodec #{@codec} #{@tmp_file_path}", @pid_file_path, @log_file_path)
+      extra = @extra.join(' ')
+
+      CliUtil.fork_process("#{CliUtil.path_to('ffmpeg')} -y -r #{@frame_rate} #{group_of_pic_size_option} -s #{dimensions} -f x11grab -i :#{@display} -vcodec #{@codec} #{extra} #{@tmp_file_path}", @pid_file_path, @log_file_path)
       at_exit do
         exit_status = $!.status if $!.is_a?(SystemExit)
         stop_and_discard

--- a/spec/headless_spec.rb
+++ b/spec/headless_spec.rb
@@ -147,18 +147,44 @@ describe Headless do
   context "#take_screenshot" do
     let(:headless) { Headless.new }
 
-    it "raises an error if imagemagick is not installed" do
-      Headless::CliUtil.stub(:application_exists?).and_return(false)
-
-      lambda { headless.take_screenshot }.should raise_error(Headless::Exception)
+    it "raises an error if unknown value for option :using is used" do
+      expect { headless.take_screenshot('a.png', using: :teleportation) }.to raise_error(Headless::Exception)
     end
 
-    it "issues command to take screenshot" do
-      headless = Headless.new
+    it "raises an error if imagemagick is not installed, with default options" do
+      Headless::CliUtil.stub(:application_exists?).with('import').and_return(false)
 
-      Headless.any_instance.should_receive(:system)
+      expect { headless.take_screenshot('a.png') }.to raise_error(Headless::Exception)
+    end
 
+    it "raises an error if imagemagick is not installed, with using: :import" do
+      Headless::CliUtil.stub(:application_exists?).with('import').and_return(false)
+
+      expect { headless.take_screenshot('a.png', using: :import) }.to raise_error(Headless::Exception)
+    end
+
+    it "raises an error if xwd is not installed, with using: :xwd" do
+      Headless::CliUtil.stub(:application_exists?).with('xwd').and_return(false)
+
+      expect { headless.take_screenshot('a.png', using: :xwd) }.to raise_error(Headless::Exception)
+    end
+
+    it "issues command to take screenshot, with default options" do
+      allow(Headless::CliUtil).to receive(:path_to).with('import').and_return('path/import')
+      expect(headless).to receive(:system).with("path/import -display localhost:99 -window root /tmp/image.png")
       headless.take_screenshot("/tmp/image.png")
+    end
+
+    it "issues command to take screenshot, with using: :import" do
+      allow(Headless::CliUtil).to receive(:path_to).with('import').and_return('path/import')
+      expect(headless).to receive(:system).with("path/import -display localhost:99 -window root /tmp/image.png")
+      headless.take_screenshot("/tmp/image.png", using: :import)
+    end
+
+    it "issues command to take screenshot, with using: :xwd" do
+      allow(Headless::CliUtil).to receive(:path_to).with('xwd').and_return('path/xwd')
+      expect(headless).to receive(:system).with("path/xwd -display localhost:99 -silent -root -out /tmp/image.png")
+      headless.take_screenshot("/tmp/image.png", using: :xwd)
     end
   end
 


### PR DESCRIPTION
There are two flavors of ffmpeg that one may need to work with. One is the kind supplied by the libav team (it is what you get on ubuntu when you install the packaged ffmpeg). The other is supplied by the ffmpeg team. These two versions have slight variations in their command line syntax. For example, the libav version accepts WIDTHxHEIGHTxBITs dimension, while ffmpeg developer's version expects only WIDTHxHEIGHT. Also the latter does not recognize the -g option.

Sometimes it is also required to pass extra parameters to ffmpeg.

This pull request addresses both items. It adds an option for passing which flavor of ffmpeg is used (:provider option). And it accepts an array of extra ffmpeg parameters which are passed to ffmpeg when it is launched (:extra option).