### PR TITLE
Smarter destroy_at_exit option default

### DIFF
--- a/lib/headless.rb
+++ b/lib/headless.rb
@@ -61,9 +61,9 @@ class Headless
   # List of available options:
   # * +display+ (default 99) - what display number to listen to;
   # * +reuse+ (default true) - if given display server already exists, should we use it or try another?
-  # * +autopick+ (default true is display number isn't explicitly set) - if Headless should automatically pick a display, or fail if the given one is not available.
+  # * +autopick+ (default true if display number isn't explicitly set) - if Headless should automatically pick a display, or fail if the given one is not available.
   # * +dimensions+ (default 1280x1024x24) - display dimensions and depth. Not all combinations are possible, refer to +man Xvfb+.
-  # * +destroy_at_exit+ (default true) - if a display is started but not stopped, should it be destroyed when the script finishes?
+  # * +destroy_at_exit+ (default true unless reuse is true and a server is already running) - if a display is started but not stopped, should it be destroyed when the script finishes?
   def initialize(options = {})
     CliUtil.ensure_application_exists!('Xvfb', 'Xvfb not found on your system')
 
@@ -72,7 +72,9 @@ class Headless
     @reuse_display = options.fetch(:reuse, true)
     @dimensions = options.fetch(:dimensions, DEFAULT_DISPLAY_DIMENSIONS)
     @video_capture_options = options.fetch(:video, {})
-    @destroy_at_exit = options.fetch(:destroy_at_exit, true)
+
+    already_running = xvfb_running? rescue false
+    @destroy_at_exit = options.fetch(:destroy_at_exit, !(@reuse_display && already_running))
 
     # FIXME Xvfb launch should not happen inside the constructor
     attach_xvfb
@@ -94,6 +96,11 @@ class Headless
   def destroy
     stop
     CliUtil.kill_process(pid_filename)
+  end
+
+  # Whether the headless display will be destroyed when the script finishes.
+  def destroy_at_exit?
+    @destroy_at_exit
   end
 
   # Block syntax:
@@ -174,7 +181,7 @@ private
       @at_exit_hook_installed = true
       at_exit do
         exit_status = $!.status if $!.is_a?(SystemExit)
-        destroy if @destroy_at_exit
+        destroy if destroy_at_exit?
         exit exit_status if exit_status
       end
     end

--- a/spec/headless_spec.rb
+++ b/spec/headless_spec.rb
@@ -43,6 +43,10 @@ describe Headless do
         it "should reuse the existing Xvfb" do
           Headless.new(options).display.should == 99
         end
+
+        it "should not be destroyed at exit by default" do
+          Headless.new(options).destroy_at_exit?.should be(false)
+        end
       end
 
       context "and display reuse is not allowed" do
@@ -79,7 +83,7 @@ describe Headless do
       context "and display autopicking is not allowed" do
         let(:options) { {:autopick => false} }
 
-        it "should fail with and exception" do
+        it "should fail with an exception" do
           lambda { Headless.new(options) }.should raise_error(Headless::Exception)
         end
       end


### PR DESCRIPTION
The `destroy_at_exit` option now defaults to false in cases where xvfb is
already running and the `reuse` option is true.