### PR TITLE
Move -g switch after the inputs

### DIFF
--- a/lib/headless/video/video_recorder.rb
+++ b/lib/headless/video/video_recorder.rb
@@ -22,7 +22,7 @@ class Headless
     end
 
     def start_capture
-      CliUtil.fork_process("#{CliUtil.path_to('ffmpeg')} -y -r #{@frame_rate} -g 600 -s #{@dimensions} -f x11grab -i :#{@display} -vcodec #{@codec} #{@tmp_file_path}", @pid_file_path, @log_file_path)
+      CliUtil.fork_process("#{CliUtil.path_to('ffmpeg')} -y -r #{@frame_rate} -s #{@dimensions} -f x11grab -i :#{@display} -g 600 -vcodec #{@codec} #{@tmp_file_path}", @pid_file_path, @log_file_path)
       at_exit do
         exit_status = $!.status if $!.is_a?(SystemExit)
         stop_and_discard

--- a/spec/video_recorder_spec.rb
+++ b/spec/video_recorder_spec.rb
@@ -18,7 +18,7 @@ describe Headless::VideoRecorder do
   describe "#capture" do
     it "starts ffmpeg" do
       Headless::CliUtil.stub(:path_to).and_return('ffmpeg')
-      Headless::CliUtil.should_receive(:fork_process).with(/ffmpeg -y -r 30 -g 600 -s 1024x768 -f x11grab -i :99 -vcodec qtrle/, "/tmp/.headless_ffmpeg_99.pid", '/dev/null')
+      Headless::CliUtil.should_receive(:fork_process).with(/ffmpeg -y -r 30 -s 1024x768 -f x11grab -i :99 -g 600 -vcodec qtrle/, "/tmp/.headless_ffmpeg_99.pid", '/dev/null')
 
       recorder = Headless::VideoRecorder.new(99, "1024x768x32")
       recorder.start_capture
@@ -26,7 +26,7 @@ describe Headless::VideoRecorder do
 
     it "starts ffmpeg with specified codec" do
       Headless::CliUtil.stub(:path_to).and_return('ffmpeg')
-      Headless::CliUtil.should_receive(:fork_process).with(/ffmpeg -y -r 30 -g 600 -s 1024x768 -f x11grab -i :99 -vcodec libvpx/, "/tmp/.headless_ffmpeg_99.pid", '/dev/null')
+      Headless::CliUtil.should_receive(:fork_process).with(/ffmpeg -y -r 30 -s 1024x768 -f x11grab -i :99 -g 600 -vcodec libvpx/, "/tmp/.headless_ffmpeg_99.pid", '/dev/null')
 
       recorder = Headless::VideoRecorder.new(99, "1024x768x32", {:codec => 'libvpx'})
       recorder.start_capture


### PR DESCRIPTION
@leonid-shevtsov this fixes ffmpeg failing because it expects -g after the input switches.
This fixes https://github.com/leonid-shevtsov/headless/issues/52