### PR TITLE
Allow provider_binary to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,13 @@ headless = Headless.new(:video => { :frame_rate => 12, :codec => 'libx264' })
 Available options:
 
 * :codec - codec to be used by ffmpeg
-* :frame_rate    - frame rate of video capture
-* :provider      - ffmpeg provider - either :libav (default) or :ffmpeg
-* :pid_file_path - path to ffmpeg pid file, default: "/tmp/.headless_ffmpeg_#{@display}.pid"
-* :tmp_file_path - path to tmp video file,  default: "/tmp/.headless_ffmpeg_#{@display}.mov"
-* :log_file_path - ffmpeg log file,         default: "/dev/null"
-* :extra         - array of extra ffmpeg options, default: [] 
+* :frame_rate      - frame rate of video capture
+* :provider        - ffmpeg provider - either :libav (default) or :ffmpeg
+* :provider_binary - Explicit path to avconv or ffmpeg.  Only required when the binary cannot be discovered on the system $PATH.
+* :pid_file_path   - path to ffmpeg pid file, default: "/tmp/.headless_ffmpeg_#{@display}.pid"
+* :tmp_file_path   - path to tmp video file,  default: "/tmp/.headless_ffmpeg_#{@display}.mov"
+* :log_file_path   - ffmpeg log file,         default: "/dev/null"
+* :extra           - array of extra ffmpeg options, default: [] 
 
 ## Taking screenshots
 

--- a/lib/headless/video/video_recorder.rb
+++ b/lib/headless/video/video_recorder.rb
@@ -5,7 +5,7 @@ class Headless
     attr_accessor :pid_file_path, :tmp_file_path, :log_file_path
 
     # Allow end-users to override the path to the binary
-    attr_accessor :provider_binary
+    attr_accessor :provider_binary_path
 
     def initialize(display, dimensions, options = {})
       @display = display
@@ -18,13 +18,13 @@ class Headless
       @frame_rate = options.fetch(:frame_rate, 30)
       @provider = options.fetch(:provider, :libav)  # or :ffmpeg
 
-      # If no provider_binary was specified, then
+      # If no provider_binary_path was specified, then
       # make a guess based upon the provider.
-      @provider_binary = options.fetch(:provider_binary, guess_the_provider_binary)
+      @provider_binary_path = options.fetch(:provider_binary_path, guess_the_provider_binary_path)
 
       @extra = Array(options.fetch(:extra, []))
 
-      CliUtil.ensure_application_exists!(provider_binary, "#{provider_binary} not found on your system. Install it or change video recorder provider")
+      CliUtil.ensure_application_exists!(provider_binary_path, "#{provider_binary_path} not found on your system. Install it or change video recorder provider")
     end
 
     def capture_running?
@@ -63,7 +63,7 @@ class Headless
 
     private
 
-    def guess_the_provider_binary
+    def guess_the_provider_binary_path
       @provider== :libav ? 'avconv' : 'ffmpeg'
     end
 
@@ -77,7 +77,7 @@ class Headless
       end
 
       ([
-        CliUtil.path_to(provider_binary),
+        CliUtil.path_to(provider_binary_path),
         "-y",
         "-r #{@frame_rate}",
         "-s #{dimensions}",

--- a/lib/headless/video/video_recorder.rb
+++ b/lib/headless/video/video_recorder.rb
@@ -4,6 +4,9 @@ class Headless
   class VideoRecorder
     attr_accessor :pid_file_path, :tmp_file_path, :log_file_path
 
+    # Allow end-users to override the path to the binary
+    attr_accessor :provider_binary
+
     def initialize(display, dimensions, options = {})
       @display = display
       @dimensions = dimensions[/.+(?=x)/]
@@ -14,6 +17,11 @@ class Headless
       @codec = options.fetch(:codec, "qtrle")
       @frame_rate = options.fetch(:frame_rate, 30)
       @provider = options.fetch(:provider, :libav)  # or :ffmpeg
+
+      # If no provider_binary was specified, then
+      # make a guess based upon the provider.
+      @provider_binary = options.fetch(:provider_binary, guess_the_provider_binary)
+
       @extra = Array(options.fetch(:extra, []))
 
       CliUtil.ensure_application_exists!(provider_binary, "#{provider_binary} not found on your system. Install it or change video recorder provider")
@@ -55,8 +63,8 @@ class Headless
 
     private
 
-    def provider_binary
-      @provider==:libav ? 'avconv' : 'ffmpeg'
+    def guess_the_provider_binary
+      @provider== :libav ? 'avconv' : 'ffmpeg'
     end
 
     def command_line_for_capture

--- a/spec/video_recorder_spec.rb
+++ b/spec/video_recorder_spec.rb
@@ -9,34 +9,34 @@ describe Headless::VideoRecorder do
 
   describe "instantiation" do
 
-    it "throws an error if provider_binary is not installed" do
+    it "throws an error if provider_binary_path is not installed" do
       allow(Headless::CliUtil).to receive(:application_exists?).and_return(false)
       expect { Headless::VideoRecorder.new(99, "1024x768x32") }.to raise_error(Headless::Exception)
     end
 
-    it "allows provider_binary to be specified" do 
+    it "allows provider_binary_path to be specified" do 
       Tempfile.open('some_provider') do |f|
-        v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :ffmpeg, provider_binary: f.path)
-        expect(v.provider_binary).to eq(f.path)
+        v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :ffmpeg, provider_binary_path: f.path)
+        expect(v.provider_binary_path).to eq(f.path)
       end
     end
 
-    it "allows provider_binary to be specified" do 
+    it "allows provider_binary_path to be specified" do 
       Tempfile.open('some_provider') do |f|
-        v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :ffmpeg, provider_binary: f.path)
-        expect(v.provider_binary).to eq(f.path)
+        v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :ffmpeg, provider_binary_path: f.path)
+        expect(v.provider_binary_path).to eq(f.path)
       end
     end
 
-    context "provider_binary not specified" do 
+    context "provider_binary_path not specified" do 
       it "assumes the provider binary is 'ffmpeg' if the provider is :ffmpeg" do 
         v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :ffmpeg)
-        expect(v.provider_binary).to eq("ffmpeg")
+        expect(v.provider_binary_path).to eq("ffmpeg")
       end
 
       it "assumes the provider binary is 'avconv' if the provider is :libav" do 
         v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :libav)
-        expect(v.provider_binary).to eq("avconv")
+        expect(v.provider_binary_path).to eq("avconv")
       end
 
     end

--- a/spec/video_recorder_spec.rb
+++ b/spec/video_recorder_spec.rb
@@ -1,17 +1,44 @@
 require 'headless'
 
+require 'tempfile'
+
 describe Headless::VideoRecorder do
   before do
     stub_environment
   end
 
   describe "instantiation" do
-    before do
+
+    it "throws an error if provider_binary is not installed" do
       allow(Headless::CliUtil).to receive(:application_exists?).and_return(false)
+      expect { Headless::VideoRecorder.new(99, "1024x768x32") }.to raise_error(Headless::Exception)
     end
 
-    it "throws an error if ffmpeg is not installed" do
-      expect { Headless::VideoRecorder.new(99, "1024x768x32") }.to raise_error(Headless::Exception)
+    it "allows provider_binary to be specified" do 
+      Tempfile.open('some_provider') do |f|
+        v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :ffmpeg, provider_binary: f.path)
+        expect(v.provider_binary).to eq(f.path)
+      end
+    end
+
+    it "allows provider_binary to be specified" do 
+      Tempfile.open('some_provider') do |f|
+        v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :ffmpeg, provider_binary: f.path)
+        expect(v.provider_binary).to eq(f.path)
+      end
+    end
+
+    context "provider_binary not specified" do 
+      it "assumes the provider binary is 'ffmpeg' if the provider is :ffmpeg" do 
+        v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :ffmpeg)
+        expect(v.provider_binary).to eq("ffmpeg")
+      end
+
+      it "assumes the provider binary is 'avconv' if the provider is :libav" do 
+        v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :libav)
+        expect(v.provider_binary).to eq("avconv")
+      end
+
     end
   end
 


### PR DESCRIPTION
The path to ffmpeg / avconv cannot always be discovered from the system $PATH.  In these cases, it becomes necessary for the end-user to provide the path to provider_binary explicitly.