### PR TITLE
Allow reuse of displays started by other users

### DIFF
--- a/lib/headless.rb
+++ b/lib/headless.rb
@@ -154,12 +154,9 @@ private
   def pick_available_display(display_set, can_reuse)
     display_set.each do |display_number|
       @display = display_number
-      begin
-        return true if xvfb_running? && can_reuse
-        return true if !xvfb_running? && launch_xvfb
-      rescue Errno::EPERM # display not accessible
-        next
-      end
+
+      return true if xvfb_running? && can_reuse && (xvfb_mine? || !@autopick_display)
+      return true if !xvfb_running? && launch_xvfb
     end
     raise Headless::Exception.new("Could not find an available display")
   end
@@ -192,8 +189,12 @@ private
     end while !xvfb_running?
   end
 
+  def xvfb_mine?
+    CliUtil.process_mine?(read_xvfb_pid)
+  end
+
   def xvfb_running?
-    !!read_xvfb_pid
+    (pid = read_xvfb_pid) && CliUtil.process_running?(pid)
   end
 
   def pid_filename


### PR DESCRIPTION
Headless provides more than just the automatic launching of an Xvfb
process, it also provides useful screenshot and vidcap features. It
would be nice to be able to use these features even when reusing an Xvfb
display that's managed by another user.

With this change, reuse of another user's display will be allowed if a
display was explicitly given and reuse is explicitly allowed.

fixes #48