### PR TITLE
add draw_mouse support

### DIFF
--- a/headless.gemspec
+++ b/headless.gemspec
@@ -3,7 +3,7 @@ spec = Gem::Specification.new do |s|
   s.email = 'leonid@shevtsov.me'
 
   s.name = 'headless'
-  s.version = '2.2.0'
+  s.version = '2.3.0'
   s.summary = 'Ruby headless display interface'
 
   s.description = <<-EOF

--- a/lib/headless/video/video_recorder.rb
+++ b/lib/headless/video/video_recorder.rb
@@ -64,8 +64,8 @@ class Headless
 
     private
 
-    def f_options
-      @opts[:f].join(' ') if @opts[:f].is_a?(Array)
+    def devices
+      @opts[:devices].join(' ') if @opts[:devices].is_a?(Array)
     end
 
     def guess_the_provider_binary_path
@@ -86,7 +86,7 @@ class Headless
          "-y",
          "-r #{@frame_rate}",
          "-s #{dimensions}",
-         "-f x11grab #{f_options}",
+         "-f x11grab #{devices}",
          "-i :#{@display}",
          group_of_pic_size_option,
          "-vcodec #{@codec}"

--- a/lib/headless/video/video_recorder.rb
+++ b/lib/headless/video/video_recorder.rb
@@ -23,7 +23,8 @@ class Headless
       @provider_binary_path = options.fetch(:provider_binary_path, guess_the_provider_binary_path)
 
       @extra = Array(options.fetch(:extra, []))
-      @opts = Hash(options.fetch(:opts, {}))
+      devices = Array(options.fetch(:devices, []))
+      @devices = devices.any? && devices.join(' ').prepend(' ') || ''
 
       CliUtil.ensure_application_exists!(provider_binary_path, "#{provider_binary_path} not found on your system. Install it or change video recorder provider")
     end
@@ -64,10 +65,6 @@ class Headless
 
     private
 
-    def devices
-      @opts[:devices].to_a.any? && @opts[:devices].join(' ').prepend(' ') || ''
-    end
-
     def guess_the_provider_binary_path
       @provider== :libav ? 'avconv' : 'ffmpeg'
     end
@@ -86,7 +83,7 @@ class Headless
          "-y",
          "-r #{@frame_rate}",
          "-s #{dimensions}",
-         "-f x11grab#{devices}",
+         "-f x11grab#{@devices}",
          "-i :#{@display}",
          group_of_pic_size_option,
          "-vcodec #{@codec}"

--- a/lib/headless/video/video_recorder.rb
+++ b/lib/headless/video/video_recorder.rb
@@ -65,7 +65,7 @@ class Headless
     private
 
     def devices
-      @opts[:devices].join(' ') if @opts[:devices].is_a?(Array)
+      @opts[:devices].to_a.any? && @opts[:devices].join(' ').prepend(' ') || ''
     end
 
     def guess_the_provider_binary_path
@@ -86,7 +86,7 @@ class Headless
          "-y",
          "-r #{@frame_rate}",
          "-s #{dimensions}",
-         "-f x11grab #{devices}",
+         "-f x11grab#{devices}",
          "-i :#{@display}",
          group_of_pic_size_option,
          "-vcodec #{@codec}"

--- a/lib/headless/video/video_recorder.rb
+++ b/lib/headless/video/video_recorder.rb
@@ -23,6 +23,7 @@ class Headless
       @provider_binary_path = options.fetch(:provider_binary_path, guess_the_provider_binary_path)
 
       @extra = Array(options.fetch(:extra, []))
+      @opts = Hash(options.fetch(:opts, {}))
 
       CliUtil.ensure_application_exists!(provider_binary_path, "#{provider_binary_path} not found on your system. Install it or change video recorder provider")
     end
@@ -63,6 +64,10 @@ class Headless
 
     private
 
+    def f_options
+      @opts[:f].join(' ') if @opts[:f].is_a?(Array)
+    end
+
     def guess_the_provider_binary_path
       @provider== :libav ? 'avconv' : 'ffmpeg'
     end
@@ -77,14 +82,14 @@ class Headless
       end
 
       ([
-        CliUtil.path_to(provider_binary_path),
-        "-y",
-        "-r #{@frame_rate}",
-        "-s #{dimensions}",
-        "-f x11grab",
-        "-i :#{@display}",
-        group_of_pic_size_option,
-        "-vcodec #{@codec}"
+         CliUtil.path_to(provider_binary_path),
+         "-y",
+         "-r #{@frame_rate}",
+         "-s #{dimensions}",
+         "-f x11grab #{f_options}",
+         "-i :#{@display}",
+         group_of_pic_size_option,
+         "-vcodec #{@codec}"
       ].compact + @extra + [@tmp_file_path]).join(' ')
     end
   end

--- a/spec/video_recorder_spec.rb
+++ b/spec/video_recorder_spec.rb
@@ -71,7 +71,7 @@ describe Headless::VideoRecorder do
     it "starts ffmpeg with specified extra device options" do
       expect(Headless::CliUtil).to receive(:fork_process).with(/^ffmpeg -y -r 30 -s 1024x768 -f x11grab -draw_mouse 0 -i :99 -g 600 -vcodec qtrle [^ ]+$/, "/tmp/.headless_ffmpeg_99.pid", '/dev/null')
 
-      recorder = Headless::VideoRecorder.new(99, "1024x768x32", { :opts => {:devices => ["-draw_mouse 0"]} })
+      recorder = Headless::VideoRecorder.new(99, "1024x768x32", {:devices => ["-draw_mouse 0"]})
       recorder.start_capture
     end
   end

--- a/spec/video_recorder_spec.rb
+++ b/spec/video_recorder_spec.rb
@@ -68,7 +68,7 @@ describe Headless::VideoRecorder do
       recorder.start_capture
     end
 
-    it "starts ffmpeg with specified extra display options" do
+    it "starts ffmpeg with specified extra device options" do
       expect(Headless::CliUtil).to receive(:fork_process).with(/^ffmpeg -y -r 30 -s 1024x768 -f x11grab -draw_mouse 0 -i :99 -g 600 -vcodec qtrle [^ ]+$/, "/tmp/.headless_ffmpeg_99.pid", '/dev/null')
 
       recorder = Headless::VideoRecorder.new(99, "1024x768x32", { :opts => {:devices => ["-draw_mouse 0"]} })

--- a/spec/video_recorder_spec.rb
+++ b/spec/video_recorder_spec.rb
@@ -14,27 +14,27 @@ describe Headless::VideoRecorder do
       expect { Headless::VideoRecorder.new(99, "1024x768x32") }.to raise_error(Headless::Exception)
     end
 
-    it "allows provider_binary_path to be specified" do 
+    it "allows provider_binary_path to be specified" do
       Tempfile.open('some_provider') do |f|
         v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :ffmpeg, provider_binary_path: f.path)
         expect(v.provider_binary_path).to eq(f.path)
       end
     end
 
-    it "allows provider_binary_path to be specified" do 
+    it "allows provider_binary_path to be specified" do
       Tempfile.open('some_provider') do |f|
         v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :ffmpeg, provider_binary_path: f.path)
         expect(v.provider_binary_path).to eq(f.path)
       end
     end
 
-    context "provider_binary_path not specified" do 
-      it "assumes the provider binary is 'ffmpeg' if the provider is :ffmpeg" do 
+    context "provider_binary_path not specified" do
+      it "assumes the provider binary is 'ffmpeg' if the provider is :ffmpeg" do
         v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :ffmpeg)
         expect(v.provider_binary_path).to eq("ffmpeg")
       end
 
-      it "assumes the provider binary is 'avconv' if the provider is :libav" do 
+      it "assumes the provider binary is 'avconv' if the provider is :libav" do
         v = Headless::VideoRecorder.new(99, "1024x768x32", provider: :libav)
         expect(v.provider_binary_path).to eq("avconv")
       end
@@ -65,6 +65,13 @@ describe Headless::VideoRecorder do
       expect(Headless::CliUtil).to receive(:fork_process).with(/^ffmpeg -y -r 30 -s 1024x768 -f x11grab -i :99 -vcodec qtrle [^ ]+$/, "/tmp/.headless_ffmpeg_99.pid", '/dev/null')
 
       recorder = Headless::VideoRecorder.new(99, "1024x768x32", {:provider => :ffmpeg})
+      recorder.start_capture
+    end
+
+    it "starts ffmpeg with specified extra display options" do
+      expect(Headless::CliUtil).to receive(:fork_process).with(/^ffmpeg -y -r 30 -s 1024x768 -f x11grab -draw_mouse 0 -i :99 -g 600 -vcodec qtrle [^ ]+$/, "/tmp/.headless_ffmpeg_99.pid", '/dev/null')
+
+      recorder = Headless::VideoRecorder.new(99, "1024x768x32", { :opts => {:f => ["-draw_mouse 0"]} })
       recorder.start_capture
     end
   end
@@ -100,7 +107,7 @@ describe Headless::VideoRecorder do
     end
   end
 
-private
+  private
 
   def stub_environment
     allow(Headless::CliUtil).to receive(:application_exists?).and_return(true)

--- a/spec/video_recorder_spec.rb
+++ b/spec/video_recorder_spec.rb
@@ -71,7 +71,7 @@ describe Headless::VideoRecorder do
     it "starts ffmpeg with specified extra display options" do
       expect(Headless::CliUtil).to receive(:fork_process).with(/^ffmpeg -y -r 30 -s 1024x768 -f x11grab -draw_mouse 0 -i :99 -g 600 -vcodec qtrle [^ ]+$/, "/tmp/.headless_ffmpeg_99.pid", '/dev/null')
 
-      recorder = Headless::VideoRecorder.new(99, "1024x768x32", { :opts => {:f => ["-draw_mouse 0"]} })
+      recorder = Headless::VideoRecorder.new(99, "1024x768x32", { :opts => {:devices => ["-draw_mouse 0"]} })
       recorder.start_capture
     end
   end


### PR DESCRIPTION
 ... (and likely partial support for similar provider devices)

this one did the work for me.
and seems to support all "devices" for at least x11grab and gdigrab

https://www.ffmpeg.org/ffmpeg-devices.html
draw_mouse is supported as [gdigrab-device](https://www.ffmpeg.org/ffmpeg-devices.html#Options-3) and [x11grab-device](https://www.ffmpeg.org/ffmpeg-devices.html#Options-10)

consider this also: 
adding support for more complicate ffmpeg tasks/switches/options, could be easier with a custom command, lets say
    { :video => { :cmd => "..ffmpeg custom command here.." } }
