### PR TITLE
Preventing $DISPLAY unset prematurely with #destroy

### DIFF
--- a/lib/headless.rb
+++ b/lib/headless.rb
@@ -100,9 +100,9 @@ class Headless
     hook_at_exit
   end
 
-  # Switches back from the headless server
+  # Switches back from the headless server if headless server was started
   def stop
-    ENV['DISPLAY'] = @old_display
+    ENV['DISPLAY'] = @old_display if @old_display
   end
 
   # Switches back from the headless server and terminates the headless session

--- a/spec/headless_spec.rb
+++ b/spec/headless_spec.rb
@@ -145,6 +145,12 @@ describe Headless do
           headless.destroy
           expect(ENV['DISPLAY']).to eq ":31337"
         end
+
+        it "keeps display untouched if headless was not started" do
+          expect(ENV['DISPLAY']).to eq ":31337"
+          headless.destroy
+          expect(ENV['DISPLAY']).to eq ":31337"
+        end
       end
     end
 


### PR DESCRIPTION
`#destroy` is pretty nonchalant about setting `$DISPLAY` to `nil` when `@old_display` was never set.