### PR TITLE
Remove localhost from imagemagick import screenshot

### DIFF
--- a/lib/headless.rb
+++ b/lib/headless.rb
@@ -157,7 +157,7 @@ class Headless
     case using
     when :imagemagick
       CliUtil.ensure_application_exists!('import', "imagemagick is not found on your system. Please install it using sudo apt-get install imagemagick")
-      system "#{CliUtil.path_to('import')} -display localhost:#{display} -window root #{file_path}"
+      system "#{CliUtil.path_to('import')} -display :#{display} -window root #{file_path}"
     when :xwd
       CliUtil.ensure_application_exists!('xwd', "xwd is not found on your system. Please install it using sudo apt-get install X11-apps")
       system "#{CliUtil.path_to('xwd')} -display localhost:#{display} -silent -root -out #{file_path}"

--- a/spec/headless_spec.rb
+++ b/spec/headless_spec.rb
@@ -211,13 +211,13 @@ describe Headless do
 
       it "issues command to take screenshot, with default options" do
         allow(Headless::CliUtil).to receive(:path_to).with('import').and_return('path/import')
-        expect(headless).to receive(:system).with("path/import -display localhost:99 -window root /tmp/image.png")
+        expect(headless).to receive(:system).with("path/import -display :99 -window root /tmp/image.png")
         headless.take_screenshot("/tmp/image.png")
       end
 
       it "issues command to take screenshot, with using: :imagemagick" do
         allow(Headless::CliUtil).to receive(:path_to).with('import').and_return('path/import')
-        expect(headless).to receive(:system).with("path/import -display localhost:99 -window root /tmp/image.png")
+        expect(headless).to receive(:system).with("path/import -display :99 -window root /tmp/image.png")
         headless.take_screenshot("/tmp/image.png", :using => :imagemagick)
       end
 


### PR DESCRIPTION
Newest version of imagemagick (Don't know exactly which) seems to cause errors like this:
```
import: unable to open X server `localhost:100' @ error/import.c/ImportImageCommand/364.
```
See #89
Without `localhost` part everything working fine