### PR TITLE
Use `File.exist?` instead of deprecated `File.exists?`

### DIFF
--- a/lib/headless/video/video_recorder.rb
+++ b/lib/headless/video/video_recorder.rb
@@ -55,7 +55,7 @@ class Headless
 
     def stop_and_save(path)
       CliUtil.kill_process(@pid_file_path, :wait => true)
-      if File.exists? @tmp_file_path
+      if File.exist? @tmp_file_path
         begin
           FileUtils.mkdir_p(File.dirname(path))
           FileUtils.mv(@tmp_file_path, path)

--- a/spec/video_recorder_spec.rb
+++ b/spec/video_recorder_spec.rb
@@ -90,7 +90,7 @@ describe Headless::VideoRecorder do
     describe "using #stop_and_save" do
       it "stops video recording and saves file" do
         expect(Headless::CliUtil).to receive(:kill_process).with(pidfile, :wait => true)
-        expect(File).to receive(:exists?).with(tmpfile).and_return(true)
+        expect(File).to receive(:exist?).with(tmpfile).and_return(true)
         expect(FileUtils).to receive(:mv).with(tmpfile, filename)
 
         subject.stop_and_save(filename)


### PR DESCRIPTION
`File.exists?` is deprecated in Ruby 2.1+.
https://github.com/ruby/ruby/blob/faba7187c5e659d7a6da67ec844c4989fc74a8d5/file.c#L1413